### PR TITLE
[DO NOT MERGE] Preliminary support for serverbid S2S adapter

### DIFF
--- a/modules/serverbidS2SAdapter.js
+++ b/modules/serverbidS2SAdapter.js
@@ -1,0 +1,185 @@
+import Adapter from 'src/adapter';
+import bidfactory from 'src/bidfactory';
+import bidmanager from 'src/bidmanager';
+import * as utils from 'src/utils';
+import { ajax } from 'src/ajax';
+import { STATUS } from 'src/constants';
+import { queueSync, persist } from 'src/cookie';
+import adaptermanager from 'src/adaptermanager';
+
+const TYPE = 's2s';
+const DEFAULT_ENDPOINT = '//e.serverbid.com/api/v2';
+const BID_SUCCESS = 1;
+const BID_EMPTY = 2;
+
+/**
+ * S2S bidder adapter for ServerBid
+ */
+function ServerBidServerAdapter() {
+  let baseAdapter = Adapter.createNew('serverbidS2S');
+
+  const sizeMap = [null,
+    '120x90',
+    '120x90',
+    '468x60',
+    '728x90',
+    '300x250',
+    '160x600',
+    '120x600',
+    '300x100',
+    '180x150',
+    '336x280',
+    '240x400',
+    '234x60',
+    '88x31',
+    '120x60',
+    '120x240',
+    '125x125',
+    '220x250',
+    '250x250',
+    '250x90',
+    '0x0',
+    '200x90',
+    '300x50',
+    '320x50',
+    '320x480',
+    '185x185',
+    '620x45',
+    '300x125',
+    '800x250'
+  ];
+
+  let config = {};
+  baseAdapter.setConfig = function(s2sconfig) {
+    config = s2sconfig;
+  };
+
+  const bidIds = [];
+
+  baseAdapter.callBids = function(params) {
+    if (params && params.bids && utils.isArray(params.bids) && params.bids.length) {
+      const request = {
+        placements: [],
+        time: Date.now(),
+        user: {},
+        url: utils.getTopWindowUrl(),
+        referrer: document.referrer,
+        enableBotFiltering: true,
+        includePricingData: true
+      };
+
+      const bids = params.bids || [];
+      for (let i = 0; i < bids.length; i++) {
+        const bid = bids[i];
+
+        bidIds.push(bid.bidId);
+
+        const bidRequest = {
+          networkId: bid.params.networkId,
+          siteId: bid.params.siteId,
+          zoneIds: bid.params.zoneIds,
+          campaignId: bid.params.campaignId,
+          flightId: bid.params.flightId,
+          adId: bid.params.adId,
+          divName: bid.bidId,
+          adTypes: bid.params.adTypes || getAdTypes(bid.sizes),
+          bidders: bid.params.bidders
+        };
+
+        if (bidRequest.networkId && bidRequest.siteId) {
+          request.placements.push(bidRequest);
+        }
+      }
+
+      if (request.placements.length > 0) {
+        const endpoint = config.endpoint || DEFAULT_ENDPOINT;
+        const payload = JSON.stringify(request);
+        ajax(endpoint, _responseCallback, request, {
+          method: 'POST',
+          withCredentials: true,
+          contentType: 'application/json'
+        });
+      }
+    }
+  };
+
+  function _responseCallback(json) {
+    let result;
+
+    try {
+      result = JSON.parse(json);
+    } catch (error) {
+      utils.logError(error);
+    }
+
+    bidIds.forEach(function(bidId) {
+      const bidRequest = utils.getBidRequest(bidId);
+      const bids = getBids(bidId, bidRequest, result);
+      bids.forEach(function(bid) {
+        bid.bidderCode = bidRequest.bidder;
+        bidmanager.addBidResponse(bidRequest.placementCode, bid);
+      });
+    });
+  }
+
+  function getBids(bidId, bidRequest, result) {
+    const bidResponses = result && result.bids && result.bids[bidId];
+
+    // If no bids were returned, register one empty bid for the placement.
+    if (!bidResponses || bidResponses.length === 0) {
+      return [bidfactory.createBid(BID_EMPTY, bidRequest)];
+    }
+
+    return bidResponses.map(function(bidResponse) {
+      const decision = bidResponse.decision;
+      const price = decision.pricing && decision.pricing.clearPrice;
+
+      // If the bid doesn't have a price, treat it as empty.
+      if (!price) {
+        return bidfactory.createBid(BID_EMPTY, bidRequest);
+      }
+
+      const bid = bidfactory.createBid(BID_SUCCESS, bidRequest);
+
+      bid.cpm = price;
+      bid.width = decision.width;
+      bid.height = decision.height;
+
+      if (decision.contents && decision.contents.length > 0) {
+        bid.ad = decision.contents[0].body + utils.createTrackPixelHtml(decision.impressionUrl);
+      }
+      else {
+        bid.ad = null;
+      }
+
+      return bid;
+    });
+  }
+
+  function getAdTypes(sizes) {
+    const result = [];
+    sizes.forEach(function(size) {
+      const index = sizeMap.indexOf(size[0] + 'x' + size[1]);
+      if (index >= 0) {
+        result.push(index);
+      }
+    });
+    return result;
+  }
+
+  return {
+    callBids: baseAdapter.callBids,
+    createNew: ServerBidServerAdapter.createNew,
+    setConfig: baseAdapter.setConfig,
+    setBidderCode: baseAdapter.setBidderCode,
+    type: TYPE
+  };
+}
+
+ServerBidServerAdapter.createNew = function() {
+  return new ServerBidServerAdapter();
+};
+
+adaptermanager.registerBidAdapter(new ServerBidServerAdapter(), 'serverbidS2S');
+
+module.exports = ServerBidServerAdapter;

--- a/test/spec/modules/serverbidS2SAdapter_spec.js
+++ b/test/spec/modules/serverbidS2SAdapter_spec.js
@@ -1,0 +1,186 @@
+import { expect } from 'chai';
+import Adapter from 'modules/serverbidS2SAdapter';
+import bidmanager from 'src/bidmanager';
+import * as utils from 'src/utils';
+
+const ENDPOINT = '//e.serverbid.com/api/v2';
+const S2S_CONFIG = {
+  endpoint: ENDPOINT
+};
+
+const REQUEST = {
+  'bidderCode': 'serverbid',
+  'requestId': 'a4713c32-3762-4798-b342-4ab810ca770d',
+  'bidderRequestId': '109f2a181342a9',
+  'bids': [{
+    'bidder': 'serverbidS2S',
+    'params': {
+      'networkId': 9969,
+      'siteId': 730181,
+      'bidders': {
+        'example': {
+          'arg1': 42,
+          'arg2': 'abc'
+        }
+      }
+    },
+    'placementCode': 'div-gpt-ad-1487778092495-0',
+    'sizes': [
+      [728, 90],
+      [970, 90]
+    ],
+    'bidId': '2b0f82502298c9',
+    'bidderRequestId': '109f2a181342a9',
+    'requestId': 'a4713c32-3762-4798-b342-4ab810ca770d'
+  }],
+  'start': 1487883186070,
+  'auctionStart': 1487883186069,
+  'timeout': 3000
+};
+
+const RESPONSE = {
+  'user': { 'key': 'ue1-2d33e91b71e74929b4aeecc23f4376f1' },
+  'bids': {
+    '2b0f82502298c9': [
+      {
+        'bidder': 'example',
+        'decision': {
+          'adId': 2364764,
+          'creativeId': 1950991,
+          'flightId': 2788300,
+          'campaignId': 542982,
+          'clickUrl': 'http://e.serverbid.com/r',
+          'impressionUrl': 'http://e.serverbid.com/i.gif',
+          'contents': [{
+            'type': 'html',
+            'body': '<html></html>',
+            'data': {
+              'height': 90,
+              'width': 728,
+              'imageUrl': 'http://static.adzerk.net/Advertisers/b0ab77db8a7848c8b78931aed022a5ef.gif',
+              'fileName': 'b0ab77db8a7848c8b78931aed022a5ef.gif'
+            },
+            'template': 'image'
+          }],
+          'height': 90,
+          'width': 728,
+          'events': [],
+          'pricing': {'price': 0.5, 'clearPrice': 0.5, 'revenue': 0.0005, 'rateType': 2, 'eCPM': 0.5}
+        }
+      }
+    ]
+  }
+};
+
+describe('serverbidServerBidAdapter', () => {
+  let adapter;
+
+  beforeEach(() => {
+    adapter = Adapter.createNew();
+    adapter.setConfig(S2S_CONFIG);
+  });
+
+  describe('request function', () => {
+    let xhr;
+    let requests;
+    let pbConfig;
+
+    beforeEach(() => {
+      xhr = sinon.useFakeXMLHttpRequest();
+      requests = [];
+      xhr.onCreate = request => requests.push(request);
+      pbConfig = REQUEST;
+      // just a single slot
+      pbConfig.bids = [pbConfig.bids[0]];
+    });
+
+    afterEach(() => xhr.restore());
+
+    it('exists and is a function', () => {
+      expect(adapter.callBids).to.exist.and.to.be.a('function');
+    });
+
+    it('requires paramaters to make request', () => {
+      adapter.callBids({});
+      expect(requests).to.be.empty;
+    });
+
+    it('requires networkId and siteId', () => {
+      let backup = pbConfig.bids[0].params;
+      pbConfig.bids[0].params = { networkId: 1234 }; // no hbid
+      adapter.callBids(pbConfig);
+      expect(requests).to.be.empty;
+
+      pbConfig.bids[0].params = { siteId: 1234 }; // no placementid
+      adapter.callBids(pbConfig);
+      expect(requests).to.be.empty;
+
+      pbConfig.bids[0].params = backup;
+    });
+
+    it('sends bid request to ENDPOINT via POST', () => {
+      adapter.callBids(pbConfig);
+      expect(requests[0].url).to.equal(ENDPOINT);
+      expect(requests[0].method).to.equal('POST');
+    });
+  });
+
+  describe('response handler', () => {
+    let server;
+
+    beforeEach(() => {
+      server = sinon.fakeServer.create();
+      sinon.stub(bidmanager, 'addBidResponse');
+      sinon.stub(utils, 'getBidRequest').returns(REQUEST);
+    });
+
+    afterEach(() => {
+      server.restore();
+      bidmanager.addBidResponse.restore();
+      utils.getBidRequest.restore();
+    });
+
+    it('registers bids', () => {
+      server.respondWith(JSON.stringify(RESPONSE));
+
+      adapter.callBids(REQUEST);
+      server.respond();
+      sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+      const response = bidmanager.addBidResponse.firstCall.args[1];
+      expect(response).to.have.property('statusMessage', 'Bid available');
+      expect(response).to.have.property('cpm');
+      expect(response.cpm).to.be.above(0);
+    });
+
+    it('handles nobid responses', () => {
+      server.respondWith(JSON.stringify({
+        'decisions': []
+      }));
+
+      adapter.callBids(REQUEST);
+      server.respond();
+      sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+      const response = bidmanager.addBidResponse.firstCall.args[1];
+      expect(response).to.have.property(
+        'statusMessage',
+        'Bid returned empty or error response'
+      );
+    });
+
+    it('handles JSON.parse errors', () => {
+      server.respondWith('');
+
+      adapter.callBids(REQUEST);
+      server.respond();
+      sinon.assert.calledOnce(bidmanager.addBidResponse);
+
+      const response = bidmanager.addBidResponse.firstCall.args[1];
+      expect(response).to.have.property(
+        'statusMessage',
+        'Bid returned empty or error response'
+      );
+    });
+  });
+});


### PR DESCRIPTION
This patch provides an example of a server-to-server adapter which can communicate with the ServerBid API. *This is not ready to merge, but is just presented as an example!*

Each ad unit on the request will contain a new property called `bidders`, which is an object describing which bidding partners should be contacted and specifies the partner-specific parameters for the placement.

For example:

```js
var adUnits = [{
  code: 'div123',
  sizes: [[300, 250], [300,600]],
  bids: [{
    bidder: 'serverbidS2S',
    params: {
      networkId: 333,
      siteId: 444,
      bidders: {
        'example-partner-1': { arg1: 42, arg2: 'abc' },
        'example-partner-2': { foo: 123, bar: 456 }
      }
    }
  }]
}];
```

This should result in a request being sent to the bid partners with codes `example-partner-1` and
`example-partner-2` with the arguments specified.

The response returned should include a bid result from each bid partner requested in the Prebid.js ad unit. Since the ServerBid API currently doesn't support returning more than one decision for each placement, a new object called `bids` should be returned instead. This object is a hash from Prebid.js bid id (that is, divName) to an array of responses from bid partners.

An example JSON response might be:

```js
{
  "user": { "key": "ue1-2d33e91b71e74929b4aeecc23f4376f1" },
  "bids": {
    "div123": [
      {
        "bidder": "example-partner-1",
        "decision": {
          "adId": 123,
          "creativeId": 456,
          "flightId": 789,
          "campaignId": 012,
          // ...
          "price": {
            "clearPrice": 0.5,
            // ...
          }
        }
      },
      {
        "bidder": "example-partner-2",
        "decision": {
          "adId": 987,
          "creativeId": 654,
          "flightId": 321,
          "campaignId": 582,
          // ...
          "price": {
            "clearPrice": 0.6,
            // ...
          }
        }
      }
    ]
  }
}
```

As with the existing ServerBid adapter, a bid returned without a valid value for `price.clearPrice`
will be treated as empty.

Alternatively, you might consider making each decision optionally be an array, but I wanted to avoid creating a breaking change to the existing API. If somehow this new response was received by an existing client of the ServerBid API, it would be treated as though there were no responses.

Another alternative structure would be to use a hash from bid partner code to decision, as in:

```js
{
  "user": { "key": "ue1-2d33e91b71e74929b4aeecc23f4376f1" },
  "bids": {
    "div123": {
      "example-partner-1": {
        "adId": 123,
        "creativeId": 456,
        "flightId": 789,
        "campaignId": 012,
        // ...
        "price": {
          "clearPrice": 0.5,
          // ...
        }
      },
      // ...
    }
  }
}
```

This would require a simple change to the S2S adapter. However, this may prove to be less flexible than the array approach, since it would restrict the results to one bid per partner.